### PR TITLE
fix: remove addition of '\r' when putchar '\n'

### DIFF
--- a/lib/sbi/sbi_console.c
+++ b/lib/sbi/sbi_console.c
@@ -40,8 +40,6 @@ int sbi_getc(void)
 void sbi_putc(char ch)
 {
 	if (console_dev && console_dev->console_putc) {
-		if (ch == '\n')
-			console_dev->console_putc('\r');
 		console_dev->console_putc(ch);
 	}
 }


### PR DESCRIPTION
OpenSBI was adding a `\r` whenever it received a `\n` to the legacy putchar function we use with HTIF console.